### PR TITLE
Initial Build Files

### DIFF
--- a/charts/argo-cd/BUILD
+++ b/charts/argo-cd/BUILD
@@ -1,0 +1,5 @@
+helm_chart(
+    name="k-argo",
+    registries=["@klaviyo-dev", "@klaviyo-eng", "@klaviyo-prod"],
+    repository="k-argo",
+)

--- a/charts/argo-events/BUILD
+++ b/charts/argo-events/BUILD
@@ -1,0 +1,1 @@
+helm_chart()

--- a/charts/argo-rollouts/BUILD
+++ b/charts/argo-rollouts/BUILD
@@ -1,0 +1,1 @@
+helm_chart()

--- a/charts/argo-workflows/BUILD
+++ b/charts/argo-workflows/BUILD
@@ -1,0 +1,1 @@
+helm_chart()

--- a/charts/argocd-apps/BUILD
+++ b/charts/argocd-apps/BUILD
@@ -1,0 +1,1 @@
+helm_chart()

--- a/charts/argocd-image-updater/BUILD
+++ b/charts/argocd-image-updater/BUILD
@@ -1,0 +1,1 @@
+helm_chart()

--- a/scripts/BUILD
+++ b/scripts/BUILD
@@ -1,0 +1,1 @@
+shell_sources()


### PR DESCRIPTION
We added k-argo as a submodule to krepo to have it build the helm charts there
- Steps to do so
1. Fork argo
2. Add submodule
3. Create k-argo pr with build files
4. Hope krepo ci will build these